### PR TITLE
Clarify get_or_create

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,9 +157,14 @@ will fail validation because it does not have a ``name``:
     ...
     django.core.exceptions.ValidationError: {'name': ['This field cannot be blank.']}
 
-*Side note:* The ``ItemFactory`` example above is used in testing
-``factory_djoy``. The ``models.py`` can be found in ``test_framework`` and the
-tests can be found in the ``tests`` folder.
+Side notes
+++++++++++
+
+* The ``ItemFactory`` example above is used in testing ``factory_djoy``. The
+  ``models.py`` can be found in ``test_framework`` and the tests can be found
+  in the ``tests`` folder.
+
+* ``CleanModelFactory`` does not provide any ``get_or_create`` behaviour.
 
 
 ``UserFactory``

--- a/tests/test_clean_model_factory.py
+++ b/tests/test_clean_model_factory.py
@@ -95,7 +95,7 @@ class TestSimpleItemFactory(TestCase):
         """
         CleanModelFactory does not provide get_or_create
         """
-        item = SimpleItemFactoryGOC(name='exist')
+        SimpleItemFactoryGOC(name='exist')
 
         with self.assertRaises(ValidationError):
             SimpleItemFactory(name='exist')

--- a/tests/test_clean_model_factory.py
+++ b/tests/test_clean_model_factory.py
@@ -13,6 +13,12 @@ class SimpleItemFactory(CleanModelFactory):
         model = Item
 
 
+class SimpleItemFactoryGOC(CleanModelFactory):
+    class Meta:
+        model = Item
+        django_get_or_create = ('name',)
+
+
 class ItemFactory(CleanModelFactory):
     class Meta:
         model = Item
@@ -84,6 +90,17 @@ class TestSimpleItemFactory(TestCase):
             SimpleItemFactory()
 
         self.assertEqual(['name'], list(cm.exception.error_dict.keys()))
+
+    def test_no_get_or_create(self):
+        """
+        CleanModelFactory does not provide get_or_create
+        """
+        item = SimpleItemFactoryGOC(name='exist')
+
+        with self.assertRaises(ValidationError):
+            SimpleItemFactory(name='exist')
+
+        self.assertEqual(Item.objects.count(), 1)
 
 
 class TestItemFactory(TestCase):


### PR DESCRIPTION
Fixes #6 - `django_get_or_create` as per [Factory Boy docs](http://factoryboy.readthedocs.io/en/latest/orms.html#factory.django.DjangoOptions.django_get_or_create) is not supported.