### PR TITLE
Bump test djangos

### DIFF
--- a/test_framework/requirements/django111.txt
+++ b/test_framework/requirements/django111.txt
@@ -4,5 +4,5 @@
 #
 #    pip-compile --output-file django111.txt django111.in
 #
-Django==1.11.12
-pytz==2018.4              # via django
+django==1.11.17
+pytz==2018.7              # via django

--- a/test_framework/requirements/local.txt
+++ b/test_framework/requirements/local.txt
@@ -4,31 +4,29 @@
 #
 #    pip-compile --output-file local.txt local.in
 #
-click==6.6                # via pip-tools
-decorator==4.0.10         # via ipython, traitlets
-factory-boy==2.7.0
-fake-factory==0.7.2       # via factory-boy
-first==2.0.1              # via pip-tools
-flake8==3.0.4
-ipdb==0.10.1
-ipython-genutils==0.1.0   # via traitlets
-ipython==5.1.0
-isort==4.2.5
-mccabe==0.5.2             # via flake8
-pexpect==4.2.1            # via ipython
-pickleshare==0.7.4        # via ipython
-pip-tools==1.7.0
-prompt-toolkit==1.0.8     # via ipython
-ptyprocess==0.5.1         # via pexpect
-pycodestyle==2.0.0        # via flake8
-pyflakes==1.2.3           # via flake8
-pygments==2.1.3           # via ipython
-python-dateutil==2.5.3    # via fake-factory
-simplegeneric==0.8.1      # via ipython
-six==1.10.0               # via fake-factory, pip-tools, prompt-toolkit, python-dateutil, traitlets
-traitlets==4.3.1          # via ipython
+backcall==0.1.0           # via ipython
+click==7.0                # via pip-tools
+decorator==4.3.0          # via ipython, traitlets
+factory-boy==2.11.1
+faker==1.0.1              # via factory-boy
+flake8==3.6.0
+ipdb==0.11
+ipython-genutils==0.2.0   # via traitlets
+ipython==7.2.0
+isort==4.3.4
+jedi==0.13.2              # via ipython
+mccabe==0.6.1             # via flake8
+parso==0.3.1              # via jedi
+pexpect==4.6.0            # via ipython
+pickleshare==0.7.5        # via ipython
+pip-tools==3.2.0
+prompt-toolkit==2.0.7     # via ipython
+ptyprocess==0.6.0         # via pexpect
+pycodestyle==2.4.0        # via flake8
+pyflakes==2.0.0           # via flake8
+pygments==2.3.1           # via ipython
+python-dateutil==2.7.5    # via faker
+six==1.12.0               # via faker, pip-tools, prompt-toolkit, python-dateutil, traitlets
+text-unidecode==1.2       # via faker
+traitlets==4.3.2          # via ipython
 wcwidth==0.1.7            # via prompt-toolkit
-
-# The following packages are commented out because they are
-# considered to be unsafe in a requirements file:
-# setuptools                # via ipdb, ipython

--- a/test_framework/requirements/py2.txt
+++ b/test_framework/requirements/py2.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --output-file py2.txt py2.in
 #
+funcsigs==1.0.2           # via mock
 mock==2.0.0
-pbr==1.10.0               # via mock
-six==1.10.0               # via mock
+pbr==5.1.1                # via mock
+six==1.12.0               # via mock

--- a/test_framework/test_settings.py
+++ b/test_framework/test_settings.py
@@ -1,6 +1,4 @@
 from .settings import *  # NOQA
 
 
-# Django 1.8 still has INSTALLED_APPS as a tuple
-INSTALLED_APPS = list(INSTALLED_APPS)
 INSTALLED_APPS.append('djoyapp')


### PR DESCRIPTION
Push test framework to use latest version of Django 1.11 in Python 2 and 3.