### PR TITLE
Add Python 3.8 test run in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: python
+dist: xenial
+sudo: true
 python:
-    - 3.5
-    - 3.6
-matrix:
-    include:
-        - python: 3.7
-          dist: xenial
-          sudo: true
+    - "3.5"
+    - "3.6"
+    - "3.7"
+    - "3.8"
 install: pip install tox
 script:
     - TOXENV=$(tox --listenvs | grep "py${TRAVIS_PYTHON_VERSION/./}-" | tr '\n' ',')

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,6 @@
 [tox]
 envlist =
-    py{35,36,37,38}-django{111,21}
-    # Only Xenial on Travis provides SQLite 3.8.3 or later currently, required
-    # by Django 22.
-    py{37,38}-django22
+    py{35,36,37,38}-django{111,21,22}
     py35-lint
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{35,36,37}-django{111,21}
+    py{35,36,37,38}-django{111,21}
     # Only Xenial on Travis provides SQLite 3.8.3 or later currently, required
     # by Django 22.
-    py37-django22
+    py{37,38}-django22
     py35-lint
 
 [testenv]


### PR DESCRIPTION
Fixes #68 

* Adds Python 3.8 test environment.
* Updates Travis image to Xenial so that Django 2.2 can be tested on all supported Pythons.