### PR TITLE
Fix ReadTheDocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Build all formats like pdf, htmlzip, etc
+formats: all
+
+python:
+   install:
+   - requirements: requirements/docs.txt

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Factory Djoy is compatible with:
 
 * Django 2.2, 3.0 and 3.1
 
-* Python 3 (3.7, 3.8)
+* Python 3 (3.7, 3.8, 3.9, 3.10, 3.11)
 
 * Factory Boy version 2.11 or greater.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,5 +14,4 @@ Contents
    userfactory
    cleanmodelfactory
    motivation
-   contribution
    development


### PR DESCRIPTION
Fixes #118 

## Adds

* New `.readthedocs.yaml` config file for RTD.

## Changes

* Fixes Python versions listed in the README: py3.9, 3.10 and 3.11 added in #117 were missing.
* Some small fixes to docs: setting a language, cleaning contributors doc from TOC.

